### PR TITLE
Adding a visual cue when copying an event code from the user page 

### DIFF
--- a/src/components/Accounts/AccountsPage.tsx
+++ b/src/components/Accounts/AccountsPage.tsx
@@ -24,6 +24,7 @@ import { auth } from '../../firebase/firebase';
 import { GAPIContext } from '../../firebase/gapiContext';
 import { LoadingAnim } from '../utils/components/LoadingAnim';
 import LoginButton from '../utils/components/LoginButton';
+import CopyCodeButton from '../utils/components/CopyCodeButton';
 
 interface AccountsPageEvent {
   name: string;
@@ -168,7 +169,8 @@ export default function AccountsPage() {
                   <div className="grid gap-5 sm:gap-5.5 md:gap-6 lg:gap-7 xl:gap-8">
                     <hr />
                     <div className="grid grid-cols-2 gap-3 xs:gap-4 sm:gap-6 md:gap-5 xl:gap-6">
-                      <button
+                      <CopyCodeButton customEventCode={event.id}/>
+                      {/* <button
                         onClick={() => {
                           copy(event.id);
                         }}
@@ -176,7 +178,7 @@ export default function AccountsPage() {
                       >
                         {event.id}
                         <IconCopy className="inline-block w-4 lg:w-5" />
-                      </button>
+                      </button> */}
                       <button
                         onClick={() => {
                           nav('/groupview/' + event.id);

--- a/src/components/GroupView/GroupViewPage.tsx
+++ b/src/components/GroupView/GroupViewPage.tsx
@@ -247,7 +247,7 @@ export default function GroupViewPage({ isAdmin }: GroupViewProps) {
             {eventDescription}
           </div>
 
-          <CopyCodeButton />
+          <CopyCodeButton/>
 
           {locationOptions.length > 0 && (
             <div className="hidden lg:block">

--- a/src/components/utils/components/CopyCodeButton.tsx
+++ b/src/components/utils/components/CopyCodeButton.tsx
@@ -3,7 +3,11 @@ import copy from 'clipboard-copy';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-export default function CopyCodeButton() {
+type CopyCodeButtonProps = {
+  customEventCode?: string;
+};
+
+export default function CopyCodeButton({ customEventCode }: CopyCodeButtonProps = {}) {
   const [copied, setCopied] = useState(false);
   const { code } = useParams();
 
@@ -21,7 +25,7 @@ export default function CopyCodeButton() {
       } border border-slate-300 font-medium py-0.5 sm:py-1 lg:py-1.5 px-5 rounded-lg transition-colors relative`}
     >
       {<IconCopy className="inline-block w-4 lg:w-5 mr-2" />}
-      {copied ? 'Copied to Clipboard' : `Share Link: ${code}`}
+      {copied ? 'Copied to Clipboard' : `Share Link: ${customEventCode? customEventCode : code}`}
     </button>
   );
 }

--- a/src/components/utils/components/CopyCodeButton.tsx
+++ b/src/components/utils/components/CopyCodeButton.tsx
@@ -25,7 +25,7 @@ export default function CopyCodeButton({ customEventCode }: CopyCodeButtonProps 
       } border border-slate-300 font-medium py-0.5 sm:py-1 lg:py-1.5 px-5 rounded-lg transition-colors relative`}
     >
       {<IconCopy className="inline-block w-4 lg:w-5 mr-2" />}
-      {copied ? 'Copied to Clipboard' : `Share Link: ${customEventCode? customEventCode : code}`}
+      {copied ? 'Copied Link' : `${customEventCode? customEventCode : code}`}
     </button>
   );
 }

--- a/src/components/utils/components/CopyCodeButton.tsx
+++ b/src/components/utils/components/CopyCodeButton.tsx
@@ -10,11 +10,12 @@ type CopyCodeButtonProps = {
 export default function CopyCodeButton({ customEventCode }: CopyCodeButtonProps = {}) {
   const [copied, setCopied] = useState(false);
   const { code } = useParams();
+  const usedCode = customEventCode ? customEventCode : code;
 
   return (
     <button
       onClick={() => {
-        copy(`${window.location.origin}/timeselect/${code}`);
+        copy(`${window.location.origin}/timeselect/${usedCode}`);
         setCopied(true);
         setTimeout(() => setCopied(false), 1500);
       }}
@@ -25,7 +26,7 @@ export default function CopyCodeButton({ customEventCode }: CopyCodeButtonProps 
       } border border-slate-300 font-medium py-0.5 sm:py-1 lg:py-1.5 px-5 rounded-lg transition-colors relative`}
     >
       {<IconCopy className="inline-block w-4 lg:w-5 mr-2" />}
-      {copied ? 'Copied Link' : `${customEventCode? customEventCode : code}`}
+      {copied ? 'Copied Link' : `${usedCode}`}
     </button>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,8 @@ import './index.css';
 import Root from './Root';
 import { Favi } from './components/navbar/CalendarIcon';
 
+// hi from nikita
+
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 root.render(
   <>


### PR DESCRIPTION
Added an optional prop to the CopyCodeButton component. This prop passes customEventCode to the, which allows us to use the component on the user events page. Earlier, this was impossible, since the CopyCodeButton relied on the useParams() hook, and hence, on the URL of the website to retrieve an event code.