### PR TITLE
event name/description wrapping fixed

### DIFF
--- a/src/components/Accounts/AccountsPage.tsx
+++ b/src/components/Accounts/AccountsPage.tsx
@@ -159,7 +159,7 @@ export default function AccountsPage() {
                   className="bg-white dark:bg-secondary_background-dark dark:text-text-dark rounded-xl lg:rounded-2xl border shadow-sm grid gap-2 sm:gap-2.5 md:gap-3 lg:gap-3.5 xl:gap-4 p-6 sm:p-7 md:p-8 lg:p-9 xl:p-10"
                 >
                   <div className="flex justify-between items-center gap-4 sm:gap-4.5 md:gap-5 lg:gap-5.5 xl:gap-6">
-                    <h3 className="md:text-lg lg:text-xl font-medium text-slate-800 dark:text-text-dark">
+                    <h3 className="md:text-lg lg:text-xl font-medium text-slate-800 dark:text-text-dark" style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}>
                       {event.name}
                     </h3>
                     {/* Do we want to enable users to edit their events? */}
@@ -208,9 +208,9 @@ export default function AccountsPage() {
           </div>
         ) : events !== undefined ? (
           getAccountId() === '' ? (
-            <div>You are logged in as a guest. </div>
+            <div className="text-slate-700 dark:text-white">You are logged in as a guest.</div>
           ) : (
-            <div>You have no events.</div>
+            <div className="text-slate-700 dark:text-white">You have no events.</div>
           )
         ) : undefined}
 

--- a/src/components/GroupView/GroupViewPage.tsx
+++ b/src/components/GroupView/GroupViewPage.tsx
@@ -241,10 +241,10 @@ export default function GroupViewPage({ isAdmin }: GroupViewProps) {
     <div className="w-full px-0 lg:px-8 lg:px-12 mb-5 lg:mb-0">
       <div className="lg:grid lg:grid-cols-4 lg:gap-2 flex flex-col">
         <div className="text-text dark:text-text-dark lg:p-0 p-4 lg:ml-5 lg:mt-5 col-span-1 gap-y-3 flex flex-col lg:items-start lg:justify-start items-center justify-center mb-3">
-          <div className="text-4xl font-bold text-center lg:text-left">
+          <div className="text-4xl font-bold text-center lg:text-left" style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}>
             {eventName}
           </div>
-          <div className="text-xl text-center lg:text-left">
+          <div className="text-xl text-center lg:text-left" style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}>
             {eventDescription}
           </div>
 

--- a/src/components/TimeSelect/TimeSelectPage.tsx
+++ b/src/components/TimeSelect/TimeSelectPage.tsx
@@ -565,10 +565,10 @@ function TimeSelectPage() {
           className="lg:p-0 p-4 lg:ml-5 lg:mt-5 lg:col-span-1 gap-y-3 flex flex-col lg:items-start lg:justify-start
            items-center justify-center mb-3 text-text dark:text-text-dark"
         >
-          <div className="text-4xl font-bold text-center lg:text-left">
+          <div className="text-4xl font-bold text-center lg:text-left" style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}>
             {eventName}
           </div>
-          <div className="text-xl text-center lg:text-left">
+          <div className="text-xl text-center lg:text-left" style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}>
             {eventDescription}
           </div>
           {locationOptions.length > 0 && (


### PR DESCRIPTION
event name/description now wraps correctly on all relevant pages (also fixed the dark mode rendering for the events page message)