### PR TITLE
Enhance gcal events rendering

### DIFF
--- a/src/components/DaySelect/day_select_component/day_select_component.tsx
+++ b/src/components/DaySelect/day_select_component/day_select_component.tsx
@@ -4,7 +4,7 @@ import CalanderComponent from '../calander_component';
 import frontendEventAPI from '../../../firebase/eventAPI';
 import { getAccountId, getAccountName } from '../../../firebase/events';
 import { useNavigate } from 'react-router-dom';
-import LimitedSelect from './limited_select_component'
+import Select from 'react-dropdown-select';
 import Button from '../../utils/components/Button';
 import InformationPopup from '../../utils/components/InformationPopup';
 import TimezonePicker from '../../utils/components/TimezonePicker';

--- a/src/components/selectCalendarComponents/CalBlock.tsx
+++ b/src/components/selectCalendarComponents/CalBlock.tsx
@@ -34,6 +34,9 @@ interface CalBlockProps {
   associatedEvents?: calendar_v3.Schema$Event[];
   onClick: React.MouseEventHandler<HTMLButtonElement>;
   theShowUserChart?: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+  isEventStart: boolean;
+  eventName: string | null;
+  additionalEventCount: number;
 }
 
 interface BoundingBox {
@@ -58,6 +61,9 @@ export default function CalBlock({
   is30Minute,
   chartedUsersData,
   theShowUserChart,
+  isEventStart,
+  eventName,
+  additionalEventCount,
 }: CalBlockProps) {
   const { theme } = useTheme();
   const [calendarState, setCalendarState] = theCalendarState;
@@ -629,6 +635,19 @@ export default function CalBlock({
         lastDragPoint.current = null;
       }}
     >
+
+      {isEventStart && eventName && (
+        <div
+          className="absolute top-0 left-0 text-xs font-bold text-black"
+          style={{
+            zIndex: 10,
+          }}
+        >
+          {eventName.length > 25 ? `${eventName.slice(0, 25)}...` : eventName}
+          {additionalEventCount > 0 && ` +${additionalEventCount}`}
+        </div>
+      )}
+
       {showTooltip && associatedEvents && associatedEvents.length > 0 && (
         <div
           className={`

--- a/src/components/selectCalendarComponents/CalBlock.tsx
+++ b/src/components/selectCalendarComponents/CalBlock.tsx
@@ -643,7 +643,7 @@ export default function CalBlock({
             zIndex: 10,
           }}
         >
-          {eventName.length > 25 ? `${eventName.slice(0, 25)}...` : eventName}
+          {eventName.length > 15 ? `${eventName.slice(0, 15)}...` : eventName}
           {additionalEventCount > 0 && ` +${additionalEventCount}`}
         </div>
       )}

--- a/src/components/selectCalendarComponents/CalRow.tsx
+++ b/src/components/selectCalendarComponents/CalRow.tsx
@@ -119,7 +119,8 @@ export default function CalRow({
                 const startTime = new Date(gEvent.start.dateTime);
                 const checkTime = new Date(gEvent.start.dateTime);
                 checkTime.setHours(hours, minutes, 0, 0);
-                return startTime.getTime() === checkTime.getTime();
+                const timeDifference = checkTime.getTime() - startTime.getTime();
+                return timeDifference >= 0 && timeDifference <= 14 * 60 * 1000;
               }
               return false;
             });

--- a/src/components/selectCalendarComponents/CalRow.tsx
+++ b/src/components/selectCalendarComponents/CalRow.tsx
@@ -9,6 +9,7 @@ import CalBlock from './CalBlock';
 import { dragProperties } from '../../types';
 import { dateObjectToComparable } from '../utils/functions/dateObjecToComparable';
 import { isTimeBetweenDates } from '../utils/functions/isTimeBetweenDates';
+import { log } from 'console';
 
 interface CalRowProps {
   bucket: calandarDate[];
@@ -68,75 +69,88 @@ export default function CalRow({
   const [googleCalendarEvents, setGoogleCalendarEvents] =
     theGoogleCalendarEvents || [];
 
-  return (
-    <div className={`grid grid-cols-${bucket.length}`}>
-      {bucket.map((d: calandarDate, columnIndex: number) => {
-        const matchedDates = googleCalendarEvents
-          ?.map((gEvent: calendar_v3.Schema$Event) => {
-            if (gEvent?.start?.dateTime && gEvent?.end?.dateTime) {
-              return [
-                new Date(gEvent.start.dateTime),
-                new Date(gEvent.end.dateTime),
-              ];
-            }
-            return null;
-          })
-          ?.filter(
-            (dates: Date[] | null) =>
-              dates !== null &&
-              dateObjectToComparable(dates[0]) ===
-                dateObjectToComparable(d.date)
-          )
-          ?.filter(
-            (dates: Date[] | null) =>
-              dates !== null &&
-              dateObjectToComparable(dates[0]) ===
+    return (
+      <div className={`grid grid-cols-${bucket.length}`}>
+        {bucket.map((d: calandarDate, columnIndex: number) => {
+          const matchedDates = googleCalendarEvents
+            ?.map((gEvent: calendar_v3.Schema$Event) => {
+              if (gEvent?.start?.dateTime && gEvent?.end?.dateTime) {
+                return [
+                  new Date(gEvent.start.dateTime),
+                  new Date(gEvent.end.dateTime),
+                ];
+              }
+              return null;
+            })
+            ?.filter(
+              (dates: Date[] | null) =>
+                dates !== null &&
+                dateObjectToComparable(dates[0]) ===
+                  dateObjectToComparable(d.date)
+            );
+    
+          const isOnGcal = matchedDates?.some((dateRange) =>
+            isTimeBetweenDates(dateRange?.[0], dateRange?.[1], time)
+          );
+    
+          const matchedEvents = googleCalendarEvents?.filter(
+            (gEvent: calendar_v3.Schema$Event) =>
+              gEvent?.start?.dateTime &&
+              dateObjectToComparable(new Date(gEvent.start.dateTime)) ===
                 dateObjectToComparable(d.date)
           );
+    
+          const surroundingEvents = matchedEvents?.filter(
+            (gEvent: calendar_v3.Schema$Event) =>
+              gEvent?.start?.dateTime &&
+              gEvent?.end?.dateTime &&
+              isTimeBetweenDates(
+                new Date(gEvent?.start?.dateTime),
+                new Date(gEvent?.end?.dateTime),
+                time
+              )
+          );
 
-        const isOnGcal = matchedDates?.some((dateRange) =>
-          isTimeBetweenDates(dateRange?.[0], dateRange?.[1], time)
-        );
+          const eventStartMatches = matchedEvents?.filter(
+            (gEvent: calendar_v3.Schema$Event) =>
+            {
+              const [hours, minutes] = time.split(':').map(Number);
+              if (gEvent?.start?.dateTime) {
+                const startTime = new Date(gEvent.start.dateTime);
+                const checkTime = new Date(gEvent.start.dateTime);
+                checkTime.setHours(hours, minutes, 0, 0);
+                return startTime.getTime() === checkTime.getTime();
+              }
+              return false;
+            });
 
-        const matchedEvents = googleCalendarEvents?.filter(
-          (gEvent: calendar_v3.Schema$Event) =>
-            gEvent?.start?.dateTime &&
-            dateObjectToComparable(new Date(gEvent.start.dateTime)) ===
-              dateObjectToComparable(d.date)
-        );
+          const eventStart = eventStartMatches?.[0] || null;
+          const isEventStart = !!eventStart;
+          const eventName = eventStart?.summary || null;
+          const additionalEventCount = eventStartMatches && eventStartMatches.length > 1 ? eventStartMatches.length - 1 : 0;
 
-        const surroundingEvents = matchedEvents?.filter(
-          (gEvent: calendar_v3.Schema$Event) =>
-            gEvent?.start?.dateTime &&
-            gEvent?.end?.dateTime &&
-            isTimeBetweenDates(
-              new Date(gEvent?.start?.dateTime),
-              new Date(gEvent?.end?.dateTime),
-              time
-            )
-        );
-
-        return (
-          // <div key={columnIndex}>hi</div>
-          <CalBlock
-            // theShowUserChart={theShowUserChart}
-            onClick={onClick}
-            theCalendarFramework={theCalendarFramework}
-            is30Minute={is30Minute}
-            theCalendarState={theCalendarState}
-            blockID={blockID}
-            columnID={columnIndex + columnIndexOffSet}
-            isAdmin={isAdmin}
-            draggable={draggable}
-            user={user}
-            theDragState={theDragState}
-            key={columnIndex + columnIndexOffSet}
-            chartedUsersData={chartedUsersData}
-            isOnGcal={isOnGcal === undefined ? false : isOnGcal}
-            associatedEvents={surroundingEvents}
-          />
-        );
-      })}
-    </div>
-  );
+          return (
+            <CalBlock
+              onClick={onClick}
+              theCalendarFramework={theCalendarFramework}
+              is30Minute={is30Minute}
+              theCalendarState={theCalendarState}
+              blockID={blockID}
+              columnID={columnIndex + columnIndexOffSet}
+              isAdmin={isAdmin}
+              draggable={draggable}
+              user={user}
+              theDragState={theDragState}
+              key={columnIndex + columnIndexOffSet}
+              chartedUsersData={chartedUsersData}
+              isOnGcal={isOnGcal === undefined ? false : isOnGcal}
+              associatedEvents={surroundingEvents}
+              isEventStart={isEventStart}
+              eventName={eventName}
+              additionalEventCount={additionalEventCount}
+            />
+          );
+        })}
+      </div>
+    );
 }


### PR DESCRIPTION
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/e3305ddc-691e-4694-a0f4-3c375d7d2e04" />

- Displays the event name in the starting block (if multiple events share the same start time only one gets rendered along with +x). Keeping hover function for now to determine when overlapping events end (need fix later).
- Event names get truncated and ellipses get added
- I prefer the black font (but if someone prefers a different one let me know)