### PR TITLE
Timeselect + Groupview SPA

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -12,8 +12,11 @@ import PrivacyPage from './components/Privacy/PrivacyPage';
 import { GAPIContextWrapper } from './firebase/gapiContext';
 import Banner from './components/utils/components/Banner';
 import { ThemeProvider } from './contexts/ThemeContext';
+import UnifiedAvailabilityPage from './components/UnifiedAvailabilityPage/UnifiedAvailabilityPage';
+import { useState } from 'react';
 
 function Root() {
+  const [isEditing, setIsEditing] = useState(false);
   return (
     <ThemeProvider>
       <div className="bg-background dark:bg-background-dark h-screen overflow-auto">
@@ -24,11 +27,12 @@ function Root() {
             <Routes>
               <Route path="/" element={<HomePage />} />
               <Route path="/dayselect" element={<DaySelectComponent />} />
-              <Route path="/timeselect/:code" element={<TimeSelectPage />} />
+              <Route path="/timeselect/:code" element={<TimeSelectPage isEditing={isEditing} toggleEditing={() => setIsEditing(false)} />} />
               <Route
                 path="/groupview/:code"
-                element={<ConditionalGroupViewRenderer />}
+                element={<ConditionalGroupViewRenderer isEditing={isEditing} toggleEditing={() => setIsEditing(true)} />}
               />
+              <Route path="/dashboard/:code" element={<UnifiedAvailabilityPage />} />
               <Route path="/useraccount" element={<AccountsPage />} />
               <Route path="/about-us" element={<AboutUsPage />} />
               <Route path="/privacy" element={<PrivacyPage />} />

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -27,11 +27,6 @@ function Root() {
             <Routes>
               <Route path="/" element={<HomePage />} />
               <Route path="/dayselect" element={<DaySelectComponent />} />
-              <Route path="/timeselect/:code" element={<TimeSelectPage isEditing={isEditing} toggleEditing={() => setIsEditing(false)} />} />
-              <Route
-                path="/groupview/:code"
-                element={<ConditionalGroupViewRenderer isEditing={isEditing} toggleEditing={() => setIsEditing(true)} />}
-              />
               <Route path="/dashboard/:code" element={<UnifiedAvailabilityPage />} />
               <Route path="/useraccount" element={<AccountsPage />} />
               <Route path="/about-us" element={<AboutUsPage />} />

--- a/src/components/Accounts/AccountsPage.tsx
+++ b/src/components/Accounts/AccountsPage.tsx
@@ -207,7 +207,8 @@ export default function AccountsPage() {
 
                     <div className="flex flex-row gap-2">
                       <button
-                        onClick={() => nav(`/groupview/${event.id}`)}
+                        // onClick={() => nav(`/groupview/${event.id}`)}
+                        onClick={() => nav(`/dashboard/${event.id}`)}
                         className="flex-1 bg-primary hover:bg-blue-400 text-white px-4 py-2.5 rounded-lg font-medium transition-colors"
                       >
                         Open Event

--- a/src/components/DaySelect/day_select_component/day_select_component.tsx
+++ b/src/components/DaySelect/day_select_component/day_select_component.tsx
@@ -198,7 +198,8 @@ export const DaySelectComponent = () => {
           timezone
         )
         .then((ev) => {
-          navigate('/timeselect/' + ev?.publicId);
+          // navigate('/timeselect/' + ev?.publicId);
+          navigate('/dashboard/' + ev?.publicId, { state: { isEditing: true } });
         });
     } else {
       if (selectedDates.length == 0) {
@@ -220,7 +221,8 @@ export const DaySelectComponent = () => {
           timezone
         )
         .then((ev) => {
-          navigate('/timeselect/' + ev?.publicId);
+          // navigate('/timeselect/' + ev?.publicId);
+          navigate('/dashboard/' + ev?.publicId, { state: { isEditing: true } });
         });
     }
   };

--- a/src/components/GroupView/ConditionalGroupViewRenderer.tsx
+++ b/src/components/GroupView/ConditionalGroupViewRenderer.tsx
@@ -1,6 +1,7 @@
 import { checkIfAdmin, getEventOnPageload } from '../../firebase/events';
+import { calanderState, calendarDimensions, userData } from '../../types';
 import GroupViewPage from './GroupViewPage';
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 /**
  *
@@ -9,15 +10,39 @@ import { useParams } from 'react-router-dom';
  * @returns Page Component
  */
 export default function ConditionalGroupViewRenderer({
-  isEditing,
-  toggleEditing,
+  isEditing, toggleEditing,
+  calendarState, setCalendarState,
+  calendarFramework, setCalendarFramework,
+  code,
+  chartedUsers, setChartedUsers,
+  eventName, setEventName,
+  eventDescription, setEventDescription,
+  locationVotes, setLocationVotes,
+  locationOptions, setLocationOptions,
+  adminChosenLocation, setAdminChosenLocation,
+  loading, setLoading,
+  allPeople, setAllPeople,
+  peopleStatus, setPeopleStatus,
+  allUsers, setAllUsers,
+  userHasFilled, setUserHasFilled,
 }: {
-  isEditing: boolean;
-  toggleEditing: () => void;
+    isEditing: boolean; toggleEditing: () => void;
+    calendarState: calanderState; setCalendarState: Dispatch<SetStateAction<calanderState>>;
+    calendarFramework: calendarDimensions; setCalendarFramework: Dispatch<SetStateAction<calendarDimensions>>;
+    code: string | undefined;
+    chartedUsers: userData; setChartedUsers: Dispatch<SetStateAction<userData>>;
+    eventName: string; setEventName: Dispatch<SetStateAction<string>>;
+    eventDescription: string; setEventDescription: Dispatch<SetStateAction<string>>;
+    locationVotes: any; setLocationVotes: Dispatch<SetStateAction<any>>;
+    locationOptions: string[]; setLocationOptions: Dispatch<SetStateAction<string[]>>;
+    adminChosenLocation: string | undefined; setAdminChosenLocation: Dispatch<SetStateAction<string | undefined>>;
+    loading: boolean; setLoading: Dispatch<SetStateAction<boolean>>;
+    allPeople: string[]; setAllPeople: Dispatch<SetStateAction<string[]>>;
+    peopleStatus: { [key: string]: boolean }; setPeopleStatus: Dispatch<SetStateAction<{ [key: string]: boolean }>>;
+    allUsers: userData; setAllUsers: Dispatch<SetStateAction<userData>>;
+    userHasFilled: boolean; setUserHasFilled: Dispatch<SetStateAction<boolean>>;
 }) {
   const [isAdmin, setIsAdmin] = useState(checkIfAdmin());
-
-  const { code } = useParams();
 
   useEffect(() => {
     if (code !== undefined) {
@@ -37,11 +62,45 @@ export default function ConditionalGroupViewRenderer({
     <>
       {isAdmin ? (
         <div>
-          <GroupViewPage isAdmin={true} isEditing={false} toggleEditing={toggleEditing}/>
+          <GroupViewPage
+            isAdmin={true}
+            isEditing={false} toggleEditing={toggleEditing}
+            calendarState={calendarState} setCalendarState={setCalendarState}
+            calendarFramework={calendarFramework} setCalendarFramework={setCalendarFramework}
+            code={code}
+            chartedUsers={chartedUsers} setChartedUsers={setChartedUsers}
+            eventName={eventName} setEventName={setEventName}
+            eventDescription={eventDescription} setEventDescription={setEventDescription}
+            locationVotes={locationVotes} setLocationVotes={setLocationVotes}
+            locationOptions={locationOptions} setLocationOptions={setLocationOptions}
+            adminChosenLocation={adminChosenLocation} setAdminChosenLocation={setAdminChosenLocation}
+            loading={loading} setLoading={setLoading}
+            allPeople={allPeople} setAllPeople={setAllPeople}
+            peopleStatus={peopleStatus} setPeopleStatus={setPeopleStatus}
+            allUsers={allUsers} setAllUsers={setAllUsers}
+            userHasFilled={userHasFilled} setUserHasFilled={setUserHasFilled}
+          />
         </div>
       ) : (
         <div>
-          <GroupViewPage isAdmin={false} isEditing={false} toggleEditing={toggleEditing} />
+          <GroupViewPage
+            isAdmin={false}
+            isEditing={false} toggleEditing={toggleEditing}
+            calendarState={calendarState} setCalendarState={setCalendarState}
+            calendarFramework={calendarFramework} setCalendarFramework={setCalendarFramework}
+            code={code}
+            chartedUsers={chartedUsers} setChartedUsers={setChartedUsers}
+            eventName={eventName} setEventName={setEventName}
+            eventDescription={eventDescription} setEventDescription={setEventDescription}
+            locationVotes={locationVotes} setLocationVotes={setLocationVotes}
+            locationOptions={locationOptions} setLocationOptions={setLocationOptions}
+            adminChosenLocation={adminChosenLocation} setAdminChosenLocation={setAdminChosenLocation}
+            loading={loading} setLoading={setLoading}
+            allPeople={allPeople} setAllPeople={setAllPeople}
+            peopleStatus={peopleStatus} setPeopleStatus={setPeopleStatus}
+            allUsers={allUsers} setAllUsers={setAllUsers}
+            userHasFilled={userHasFilled} setUserHasFilled={setUserHasFilled}
+          />
         </div>
       )}
     </>

--- a/src/components/GroupView/ConditionalGroupViewRenderer.tsx
+++ b/src/components/GroupView/ConditionalGroupViewRenderer.tsx
@@ -8,7 +8,13 @@ import { useParams } from 'react-router-dom';
  *
  * @returns Page Component
  */
-export default function ConditionalGroupViewRenderer() {
+export default function ConditionalGroupViewRenderer({
+  isEditing,
+  toggleEditing,
+}: {
+  isEditing: boolean;
+  toggleEditing: () => void;
+}) {
   const [isAdmin, setIsAdmin] = useState(checkIfAdmin());
 
   const { code } = useParams();
@@ -31,11 +37,11 @@ export default function ConditionalGroupViewRenderer() {
     <>
       {isAdmin ? (
         <div>
-          <GroupViewPage isAdmin={true} />
+          <GroupViewPage isAdmin={true} isEditing={false} toggleEditing={toggleEditing}/>
         </div>
       ) : (
         <div>
-          <GroupViewPage isAdmin={false} />
+          <GroupViewPage isAdmin={false} isEditing={false} toggleEditing={toggleEditing} />
         </div>
       )}
     </>

--- a/src/components/GroupView/GroupViewPage.tsx
+++ b/src/components/GroupView/GroupViewPage.tsx
@@ -43,14 +43,19 @@ import TimezoneChanger from '../utils/components/TimezoneChanger';
 import { IconAdjustments, IconAdjustmentsFilled } from '@tabler/icons-react';
 import { filter } from 'lodash';
 
-interface GroupViewProps {
-  isAdmin: boolean;
-}
 /**
  * Group View (with all the availabilities) if you are logged in as the creator of the Event.
  * @returns Page Component
  */
-export default function GroupViewPage({ isAdmin }: GroupViewProps) {
+export default function GroupViewPage({
+  isAdmin,
+  isEditing,
+  toggleEditing,
+}: {
+  isAdmin: boolean;
+  isEditing: boolean;
+  toggleEditing: () => void;
+}) {
   const { gapi, handleIsSignedIn } = useContext(GAPIContext);
 
   const [calendarState, setCalendarState] = useState<calanderState>([]);
@@ -294,6 +299,16 @@ export default function GroupViewPage({ isAdmin }: GroupViewProps) {
           </div>
 
           <CopyCodeButton />
+
+          {/* View/Edit Availability Button */}
+          <ButtonSmall
+            bgColor="primary"
+            textColor="white"
+            onClick={toggleEditing}
+          >
+            {isEditing ? 'View Availability' : 'Edit Availability'}
+          </ButtonSmall>
+
           {isAdmin && (
             <AutoDraftEmailButton
               eventTitle={eventName}
@@ -376,7 +391,8 @@ export default function GroupViewPage({ isAdmin }: GroupViewProps) {
                         bgColor={'primary'}
                         textColor={'white'}
                         onClick={() => {
-                          nav('/timeselect/' + code);
+                          // nav('/timeselect/' + code);
+                          nav('/dashboard/' + code, { state: { isEditing: true } });
                         }}
                       >
                         <div className="flex flex-row items-center justify-center space-x-1">

--- a/src/components/GroupView/GroupViewPage.tsx
+++ b/src/components/GroupView/GroupViewPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef, Dispatch, SetStateAction } from 'react';
 import ButtonSmall from '../utils/components/ButtonSmall';
 import {
   calanderState,
@@ -49,51 +49,45 @@ import { filter } from 'lodash';
  */
 export default function GroupViewPage({
   isAdmin,
-  isEditing,
-  toggleEditing,
+  isEditing, toggleEditing,
+  calendarState, setCalendarState,
+  calendarFramework, setCalendarFramework,
+  code,
+  chartedUsers, setChartedUsers,
+  eventName, setEventName,
+  eventDescription, setEventDescription,
+  locationVotes, setLocationVotes,
+  locationOptions, setLocationOptions,
+  adminChosenLocation, setAdminChosenLocation,
+  loading, setLoading,
+  allPeople, setAllPeople,
+  peopleStatus, setPeopleStatus,
+  allUsers, setAllUsers,
+  userHasFilled, setUserHasFilled,
 }: {
   isAdmin: boolean;
-  isEditing: boolean;
-  toggleEditing: () => void;
+  isEditing: boolean; toggleEditing: () => void;
+  calendarState: calanderState; setCalendarState: Dispatch<SetStateAction<calanderState>>;
+  calendarFramework: calendarDimensions; setCalendarFramework: Dispatch<SetStateAction<calendarDimensions>>;
+  code: string | undefined;
+  chartedUsers: userData; setChartedUsers: Dispatch<SetStateAction<userData>>;
+  eventName: string; setEventName: Dispatch<SetStateAction<string>>;
+  eventDescription: string; setEventDescription: Dispatch<SetStateAction<string>>;
+  locationVotes: any; setLocationVotes: Dispatch<SetStateAction<any>>;
+  locationOptions: string[]; setLocationOptions: Dispatch<SetStateAction<string[]>>;
+  adminChosenLocation: string | undefined; setAdminChosenLocation: Dispatch<SetStateAction<string | undefined>>;
+  loading: boolean; setLoading: Dispatch<SetStateAction<boolean>>;
+  allPeople: string[]; setAllPeople: Dispatch<SetStateAction<string[]>>;
+  peopleStatus: { [key: string]: boolean }; setPeopleStatus: Dispatch<SetStateAction<{ [key: string]: boolean }>>;
+  allUsers: userData; setAllUsers: Dispatch<SetStateAction<userData>>;
+  userHasFilled: boolean; setUserHasFilled: Dispatch<SetStateAction<boolean>>;
 }) {
   const { gapi, handleIsSignedIn } = useContext(GAPIContext);
-
-  const [calendarState, setCalendarState] = useState<calanderState>([]);
-  const [calendarFramework, setCalendarFramework] =
-    useState<calendarDimensions>({
-      dates: [],
-      startTime: new Date(),
-      endTime: new Date(),
-      numOfBlocks: 0,
-      numOfCols: 0,
-    });
-
-  const { code } = useParams();
-
   const [showUserChart, setShowUserChart] = useState(false);
-  const [participantToggleClicked, setParticipantToggleClicked] =
-    useState(true);
-
-  const [chartedUsers, setChartedUsers] = useState<userData>({} as userData);
-  const [eventName, setEventName] = useState('');
-  const [eventDescription, setEventDescription] = useState('');
-
-  const [locationVotes, setLocationVotes] = useState(Object);
-  const [locationOptions, setLocationOptions] = useState(Array<string>);
+  const [participantToggleClicked, setParticipantToggleClicked] = useState(true);
   const [showLocationChart, setShowLocationChart] = useState(false);
-
-  // this is the location that admin selected on the CLIENT side
-  const [adminChosenLocation, setAdminChosenLocation] = useState<
-    string | undefined
-  >(undefined);
-
-  // this is the location the admin previously submitted / submitted to the backend, which is pulled and set
-  // or updated to be the admin location
-  const [selectedLocation, setSelectedLocation] = useState<string>();
-  const [loading, setLoading] = useState(true);
   const [showGeneralPopup, setShowGeneralPopup] = useState(false);
   const [generalPopupMessage] = useState('');
-
   const [dragState, setDragState] = useState<dragProperties>({
     isSelecting: false,
     startPoint: null,
@@ -101,20 +95,6 @@ export default function GroupViewPage({
     selectionMode: false, // true for selecting, false for deselecting
     lastPosition: null,
   });
-
-  const [allPeople, setAllPeople] = useState<string[]>([]);
-  const [peopleStatus, setPeopleStatus] = useState<{
-    [key: string]: boolean;
-  }>({});
-  const [allUsers, setAllUsers] = useState<userData>({} as userData);
-
-  const [userHasFilled, setUserHasFilled] = useState(false);
-
-  useEffect(() => {
-    setPeopleStatus(Object.fromEntries(allPeople?.map((name) => [name, true])));
-  }, [allPeople]);
-
-  const nav = useNavigate();
 
   const createCalendarEventUrl = useCallback((event: any) => {
     const startDateTime = new Date(event.start.dateTime)
@@ -151,47 +131,6 @@ export default function GroupViewPage({
     },
     [createCalendarEventUrl]
   );
-
-  useEffect(() => {
-    const fetchData = async () => {
-      if (code && code.length == 6) {
-        await getEventOnPageload(code)
-          .then(() => {
-            const { availabilities, participants } = eventAPI.getCalendar();
-            const dates = eventAPI.getCalendarDimensions();
-
-            setChartedUsers(participants);
-            setAllPeople(participants.users.map((user) => user.name));
-            setAllUsers(participants);
-            setPeopleStatus(
-              Object.fromEntries(
-                participants.users.map((user) => [user.name, true])
-              )
-            );
-
-            setUserHasFilled(participants.userIDs.includes(getAccountId()));
-
-            setCalendarState(availabilities);
-            setCalendarFramework(dates);
-
-            setEventName(getEventName());
-            setEventDescription(getEventDescription());
-            setLocationVotes(getLocationsVotes());
-            setLocationOptions(getLocationOptions());
-            setSelectedLocation(getChosenLocation());
-            setAdminChosenLocation(getChosenLocation());
-            setLoading(false);
-          })
-          .catch(() => {
-            nav('/notfound');
-          });
-      } else {
-        // url is malformed
-        nav('notfound');
-      }
-    };
-    fetchData();
-  }, []);
 
   async function handleSelectionSubmission() {
     if (!dragState.endPoint || !dragState.startPoint) {
@@ -306,7 +245,7 @@ export default function GroupViewPage({
             textColor="white"
             onClick={toggleEditing}
           >
-            {isEditing ? 'View Availability' : 'Edit Availability'}
+            {isEditing ? 'View Availabilities' : 'Edit Your Availability'}
           </ButtonSmall>
 
           {isAdmin && (
@@ -387,7 +326,7 @@ export default function GroupViewPage({
                 <div className="flex flex-col sm:flex-row items-center justify-between w-full">
                   <div className="w-full flex flex-col sm:flex-row items-center sm:space-x-2">
                     <div className="flex w-full sm:w-auto justify-center sm:justify-between mb-2 space-x-2 sm:mb-0">
-                      <ButtonSmall
+                      {/* <ButtonSmall
                         bgColor={'primary'}
                         textColor={'white'}
                         onClick={() => {
@@ -403,7 +342,7 @@ export default function GroupViewPage({
                               : 'Add Your Availability'}
                           </p>
                         </div>
-                      </ButtonSmall>
+                      </ButtonSmall> */}
 
                       <div className="sm:hidden flex items-center justify-center space-x-0">
                         {isAdmin &&

--- a/src/components/TimeSelect/TimeSelectPage.tsx
+++ b/src/components/TimeSelect/TimeSelectPage.tsx
@@ -46,7 +46,13 @@ import TimezoneChanger from '../utils/components/TimezoneChanger';
  *
  * @returns Page Component
  */
-function TimeSelectPage() {
+function TimeSelectPage({
+  isEditing,
+  toggleEditing,
+}: {
+  isEditing: boolean;
+  toggleEditing: () => void;
+}) {
   const { code } = useParams();
   const [isGcalPopupOpen, setGcalPopupOpen] = useState(false);
 
@@ -166,7 +172,8 @@ function TimeSelectPage() {
 
             // if there's a selection already made, nav to groupview since you're not allowed to edit ur avail
             if (theRange != undefined && theRange[0].getFullYear() != 1970) {
-              nav('/groupview/' + code);
+              // nav('/groupview/' + code);
+              nav('/dashboard/' + code);
             }
           })
           .catch(() => {
@@ -459,7 +466,8 @@ function TimeSelectPage() {
 
           // if there's a selection already made, nav to groupview since you're not allowed to edit ur avail
           if (theRange != undefined && theRange[0].getFullYear() != 1970) {
-            nav('/groupview/' + code);
+            // nav('/groupview/' + code);
+            nav('dashboard/' + code);
           }
         });
       } else {
@@ -568,7 +576,8 @@ function TimeSelectPage() {
       ? (calendarState[user] ?? [])
       : [];
     wrappedSaveParticipantDetails(avail, selectedLocations);
-    navigate(`/groupview/${code}`);
+    // navigate(`/groupview/${code}`);
+    toggleEditing();
   };
 
   const handleSubmitAvailability = () => {
@@ -603,6 +612,15 @@ function TimeSelectPage() {
             </div>
           )}
           <CopyCodeButton />
+
+          {/* View/Edit Availability Button */}
+          <ButtonSmall
+            bgColor="primary"
+            textColor="white"
+            onClick={toggleEditing}
+          >
+            {isEditing ? 'View Availability' : 'Edit Availability'}
+          </ButtonSmall>
         </div>
         <div className="lg:col-span-3">
           <div className="w-full">

--- a/src/components/UnifiedAvailabilityPage/UnifiedAvailabilityPage.tsx
+++ b/src/components/UnifiedAvailabilityPage/UnifiedAvailabilityPage.tsx
@@ -1,21 +1,237 @@
-import { useState } from 'react';
-import GroupViewPage from '../GroupView/GroupViewPage';
+import { useState, useEffect } from 'react';
 import TimeSelectPage from '../TimeSelect/TimeSelectPage';
 import ConditionalGroupViewRenderer from '../GroupView/ConditionalGroupViewRenderer';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import eventAPI from '../../firebase/eventAPI';
+import {
+  getEventOnPageload,
+  getEventName,
+  getEventDescription,
+  getLocationOptions,
+  getAccountId,
+  getLocationsVotes,
+  getChosenLocation,
+  getAccountName,
+  getAvailabilityByAccountId,
+  getAvailabilityByName,
+  getChosenDayAndTime,
+} from '../../firebase/events';
+import {
+  calanderState,
+  userData,
+  calendarDimensions,
+  Availability,
+} from '../../types';
+import { LoadingAnim } from '../utils/components/LoadingAnim';
 
 export default function UnifiedAvailabilityPage() {
   const location = useLocation();
-  console.log('Location State:', location.state);
+  const { code } = useParams();
+
   const initialMode = location.state?.isEditing ?? false;
-  const [isEditing, setIsEditing] = useState(initialMode); // Toggle between Edit and View modes
+  const [isEditing, setIsEditing] = useState(initialMode);
+
+  const [loading, setLoading] = useState(true);
+
+  // groupview states
+  const [groupViewCalendarState, setGroupViewCalendarState] = useState<calanderState>([]);
+  const [groupViewCalendarFramework, setGroupViewCalendarFramework] =
+    useState<calendarDimensions>({
+    dates: [],
+    startTime: new Date(),
+    endTime: new Date(),
+    numOfBlocks: 0,
+    numOfCols: 0,
+  });
+  const [chartedUsers, setChartedUsers] = useState<userData>({} as userData);
+  const [eventName, setEventName] = useState('');
+  const [eventDescription, setEventDescription] = useState('');
+  const [locationOptions, setLocationOptions] = useState(Array<string>);
+  const [allPeople, setAllPeople] = useState<string[]>([]);
+  const [allUsers, setAllUsers] = useState<userData>({} as userData);
+  const [peopleStatus, setPeopleStatus] = useState<{
+    [key: string]: boolean;
+  }>({});
+  useEffect(() => {
+    setPeopleStatus(Object.fromEntries(allPeople?.map((name) => [name, true])));
+  }, [allPeople]);
+  const [userHasFilled, setUserHasFilled] = useState(false);
+  const [locationVotes, setLocationVotes] = useState(Object);
+  const [adminChosenLocation, setAdminChosenLocation] = useState<
+    string | undefined
+  >(undefined);
+
+
+  // time select states
+  const [timeSelectCalendarState, setTimeSelectCalendarState] = useState<calanderState>([]);
+  const [timeSelectCalendarFramework, setTimeSelectCalendarFramework] =
+    useState<calendarDimensions>({
+      dates: [],
+      startTime: new Date(),
+      endTime: new Date(),
+      numOfBlocks: 0,
+      numOfCols: 0,
+    });
+  const [hasAvailability, setHasAvailability] = useState(false);
+  const [isGeneralDays, setIsGeneralDays] = useState(
+    timeSelectCalendarFramework?.dates?.[0]?.[0]?.date?.getFullYear() === 2000
+  );
+  const [areSelectingGeneralDays, setAreSelectingGeneralDays] = useState(false);
+  const [promptUserForLogin, setPromptUserForLogin] = useState(false);
+
+  const nav = useNavigate();
+
+  const fetchData = async (setLoadingState: boolean = true, onSuccess?: () => void) => {
+    if (setLoadingState) {
+      setLoading(true);
+    }
+  
+    if (code && code.length === 6) {
+      await getEventOnPageload(code)
+        .then(() => {
+          // groupview
+          const { availabilities, participants } = eventAPI.getCalendar();
+          const dim = eventAPI.getCalendarDimensions();
+  
+          setChartedUsers({
+            ...participants,
+            available: [],
+            unavailable: participants.users,
+          });
+          setAllPeople(participants.users.map((user) => user.name));
+          setAllUsers(participants);
+          setPeopleStatus(
+            Object.fromEntries(
+              participants.users.map((user) => [user.name, true])
+            )
+          );
+  
+          setUserHasFilled(participants.userIDs.includes(getAccountId()));
+  
+          setGroupViewCalendarState(availabilities);
+          setGroupViewCalendarFramework(dim);
+  
+          setEventName(getEventName());
+          setEventDescription(getEventDescription());
+          setLocationVotes(getLocationsVotes());
+          setLocationOptions(getLocationOptions());
+          setAdminChosenLocation(getChosenLocation());
+  
+          // time select
+          const accountName = getAccountName();
+          if (accountName === null) {
+            return;
+          }
+  
+          let avail: Availability | undefined =
+            getAccountId() !== ''
+              ? getAvailabilityByAccountId(getAccountId())
+              : getAvailabilityByName(accountName);
+  
+          if (avail === undefined) {
+            avail = eventAPI.getEmptyAvailability(dim);
+          } else {
+            setHasAvailability(true);
+          }
+  
+          const theRange = getChosenDayAndTime();
+          setIsGeneralDays(
+            dim?.dates[0][0].date?.getFullYear() === 2000 &&
+              theRange === undefined
+          );
+  
+          setTimeSelectCalendarState([...availabilities, avail]);
+          setTimeSelectCalendarFramework(dim);
+  
+          /* The first date having a year be 2000 means that it was a general days selection */
+          setAreSelectingGeneralDays(
+            dim?.dates[0][0].date?.getFullYear() === 2000 &&
+              theRange === undefined
+          );
+  
+          // if there's a selection already made, nav to groupview since you're not allowed to edit your avail
+          if (theRange !== undefined && theRange[0].getFullYear() !== 1970) {
+            nav('/dashboard/' + code);
+          }
+  
+          if (onSuccess) {
+            onSuccess();
+          }
+        })
+        .catch(() => {
+          nav('/notfound');
+        });
+  
+      if (setLoadingState) {
+        setLoading(false);
+      }
+    } else {
+      // URL is malformed
+      nav('notfound');
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="w-full h-[60%] flex flex-col items-center justify-center">
+        <LoadingAnim />
+        <p className="text-gray-500">Loading...</p>
+      </div>
+    );
+  }
 
   return (
     <div>
       {isEditing ? (
-        <TimeSelectPage isEditing={isEditing} toggleEditing={() => setIsEditing(false)} />
+        <TimeSelectPage
+          isEditing={isEditing}
+          toggleEditing={() => {
+            setIsEditing(false);
+            fetchData(false); // Fetch data without setting loading to true
+          }}
+          onFetchComplete={() => {
+            if (getAccountName() === '' || getAccountName() === undefined) {
+              setPromptUserForLogin(true);
+            }
+          }}
+          code={code}
+          chartedUsers={chartedUsers} setChartedUsers={setChartedUsers}
+          calendarState={timeSelectCalendarState} setCalendarState={setTimeSelectCalendarState}
+          calendarFramework={timeSelectCalendarFramework} setCalendarFramework={setTimeSelectCalendarFramework}
+          loading={loading} setLoading={setLoading}
+          eventName={eventName} setEventName={setEventName}
+          eventDescription={eventDescription} setEventDescription={setEventDescription}
+          locationOptions={locationOptions} setLocationOptions={setLocationOptions}
+          areSelectingGeneralDays={areSelectingGeneralDays} setAreSelectingGeneralDays={setAreSelectingGeneralDays}
+          isGeneralDays={isGeneralDays} setIsGeneralDays={setIsGeneralDays}
+          hasAvailability={hasAvailability} setHasAvailability={setHasAvailability}
+        />
       ) : (
-        <ConditionalGroupViewRenderer isEditing={isEditing} toggleEditing={() => setIsEditing(true)} />
+        <ConditionalGroupViewRenderer
+          isEditing={isEditing}
+          toggleEditing={() => {
+            setIsEditing(true);
+            fetchData(false); // Fetch data without setting loading to true
+          }}
+          calendarState={groupViewCalendarState} setCalendarState={setGroupViewCalendarState}
+          calendarFramework={groupViewCalendarFramework} setCalendarFramework={setGroupViewCalendarFramework}
+          code={code}
+          chartedUsers={chartedUsers} setChartedUsers={setChartedUsers}
+          eventName={eventName} setEventName={setEventName}
+          eventDescription={eventDescription} setEventDescription={setEventDescription}
+          locationVotes={locationVotes} setLocationVotes={setLocationVotes}
+          locationOptions={locationOptions} setLocationOptions={setLocationOptions}
+          adminChosenLocation={adminChosenLocation} setAdminChosenLocation={setAdminChosenLocation}
+          loading={loading} setLoading={setLoading}
+          allPeople={allPeople} setAllPeople={setAllPeople}
+          peopleStatus={peopleStatus} setPeopleStatus={setPeopleStatus}
+          allUsers={allUsers} setAllUsers={setAllUsers}
+          userHasFilled={userHasFilled} setUserHasFilled={setUserHasFilled}
+        />
       )}
     </div>
   );

--- a/src/components/UnifiedAvailabilityPage/UnifiedAvailabilityPage.tsx
+++ b/src/components/UnifiedAvailabilityPage/UnifiedAvailabilityPage.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import GroupViewPage from '../GroupView/GroupViewPage';
+import TimeSelectPage from '../TimeSelect/TimeSelectPage';
+import ConditionalGroupViewRenderer from '../GroupView/ConditionalGroupViewRenderer';
+import { useLocation } from 'react-router-dom';
+
+export default function UnifiedAvailabilityPage() {
+  const location = useLocation();
+  console.log('Location State:', location.state);
+  const initialMode = location.state?.isEditing ?? false;
+  const [isEditing, setIsEditing] = useState(initialMode); // Toggle between Edit and View modes
+
+  return (
+    <div>
+      {isEditing ? (
+        <TimeSelectPage isEditing={isEditing} toggleEditing={() => setIsEditing(false)} />
+      ) : (
+        <ConditionalGroupViewRenderer isEditing={isEditing} toggleEditing={() => setIsEditing(true)} />
+      )}
+    </div>
+  );
+}

--- a/src/components/selectCalendarComponents/CalBlock.tsx
+++ b/src/components/selectCalendarComponents/CalBlock.tsx
@@ -81,8 +81,6 @@ export default function CalBlock({
   const previousBoundingBox = useRef<BoundingBox | null>(null);
   const dragStartTime = useRef<number | null>(null);
 
-  console.log(isEventEnd);
-
   // Initialize chartedUsers
   useEffect(() => {
     if (chartedUsers && setChartedUsers) {

--- a/src/components/utils/components/LoginPopup/login_guest_popup.tsx
+++ b/src/components/utils/components/LoginPopup/login_guest_popup.tsx
@@ -31,7 +31,8 @@ export const LoginPopup: React.FC<LoginPopupProps> = ({
     signInWithGoogle().then((loginSuccessful) => {
       if (loginSuccessful !== false) {
         if (code !== '') {
-          navigate(`/timeselect/${code}`);
+          // navigate(`/timeselect/${code}`);
+          navigate('/dashboard/' + code, { state: { isEditing: true } });
         }
         onClose();
         document.body.classList.remove('popup-open');
@@ -92,7 +93,8 @@ export const LoginPopup: React.FC<LoginPopupProps> = ({
       <div className="popup-content w-full max-w-md bg-white rounded-2xl shadow-lg relative">
         <button
           onClick={() => {
-            navigate('/groupview/' + code);
+            // navigate('/groupview/' + code);
+            navigate('/dashboard/' + code);
           }}
           className="absolute top-4 left-4 p-2 flex items-center text-gray-500 hover:text-gray-800 transition-colors duration-200"
           aria-label="Go back"


### PR DESCRIPTION

https://github.com/user-attachments/assets/e04413d2-289a-495a-a932-8c7340c4167a

(Demo above, apologies for extremely bad video quality)

- TimeSelect and GroupView now share the same dashboard URL (/dashboard/:code)
- The two components function as edit and view modes, respectively
- Changes made in edit mode are only persisted when explicitly saved (feedback on this behavior would be appreciated)
-  Data for both components is fetched simultaneously to improve performance and ensure consistency (i think this is fine privacy-wise since anyone with the event link can access either components anyways)

I'd like to get some feedback on overall feel of this, as well some ui suggestions/enhancements (like switching between edit/view modes via a toggle button instead, placement of the buttons, etc.)