### PR TITLE
Show timezones with UTC offsets and guard Firebase analytics

### DIFF
--- a/src/backend/firebase.ts
+++ b/src/backend/firebase.ts
@@ -17,7 +17,24 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 
-const analytics = getAnalytics(app);
+// Analytics can fail to initialize when offline or in unsupported environments.
+// Guard the call so we don't throw a runtime error in development / offline usage.
+let analytics: any;
+if (
+  typeof window !== 'undefined' &&
+  typeof navigator !== 'undefined' &&
+  navigator.onLine &&
+  !!firebaseConfig.measurementId
+) {
+  try {
+    analytics = getAnalytics(app);
+  } catch (error) {
+    // Swallow analytics initialization errors so the app can keep running.
+    // eslint-disable-next-line no-console
+    console.warn('Firebase analytics could not be initialized:', error);
+  }
+}
+
 const db = getFirestore(app);
 
 export const SCOPES = 'https://www.googleapis.com/auth/calendar.readonly';

--- a/src/components/utils/components/TimezoneChanger.tsx
+++ b/src/components/utils/components/TimezoneChanger.tsx
@@ -5,7 +5,7 @@ import { DateTime } from 'luxon';
 import { datesToCalendarDates } from '../functions/dateToCalendarDate';
 import Dropdown from './Dropdown';
 import { timezones } from '../constants/timezones';
-import { doTimezoneChange } from '../functions/timzoneConversions';
+import { doTimezoneChange, formatTimezoneLabel } from '../functions/timzoneConversions';
 import { getUTCStartAndEndTimes } from '../../../backend/events';
 
 interface TimezoneChangerProps {
@@ -49,7 +49,7 @@ const TimezoneChanger = ({
         selectedOption={selectedTimezone}
         onSelect={handleTimezoneChange}
         placeholder="Select a timezone"
-        renderOption={(option) => option.replace(/_/g, ' ')}
+        renderOption={(option) => formatTimezoneLabel(option)}
         className="bg-white dark:bg-secondary_background-dark"
         searchable={true}
       />

--- a/src/components/utils/components/TimezonePicker.tsx
+++ b/src/components/utils/components/TimezonePicker.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Dropdown from '../../utils/components/Dropdown';
 import { timezones } from '../../utils/constants/timezones';
+import { formatTimezoneLabel } from '../functions/timzoneConversions';
 
 interface TimezonePickerProps {
   timezone: string;
@@ -17,7 +18,7 @@ const TimezonePicker: React.FC<TimezonePickerProps> = ({
       selectedOption={timezone}
       onSelect={setTimezone}
       placeholder="Select a timezone"
-      renderOption={(option) => option.replace(/_/g, ' ')}
+      renderOption={(option) => formatTimezoneLabel(option)}
       className="dark:bg-secondary_background-dark"
     />
   );

--- a/src/components/utils/functions/timzoneConversions.ts
+++ b/src/components/utils/functions/timzoneConversions.ts
@@ -13,6 +13,31 @@ const getTimezoneOffset = (timezone: string) => {
   return tzDate.getTime() - utcDate.getTime();
 };
 
+/**
+ * Format a timezone identifier (e.g. "America/New_York") with its current UTC offset,
+ * e.g. "America/New York (UTC-05:00)".
+ */
+export const formatTimezoneLabel = (timezone: string): string => {
+  try {
+    const offsetMs = getTimezoneOffset(timezone);
+    const offsetMinutes = Math.round(offsetMs / (1000 * 60));
+    const sign = offsetMinutes >= 0 ? '+' : '-';
+    const absMinutes = Math.abs(offsetMinutes);
+    const hours = Math.floor(absMinutes / 60);
+    const minutes = absMinutes % 60;
+    const offsetStr = `UTC${sign}${hours.toString().padStart(2, '0')}:${minutes
+      .toString()
+      .padStart(2, '0')}`;
+
+    // Replace underscores with spaces for a cleaner display name
+    const prettyName = timezone.replace(/_/g, ' ');
+    return `${prettyName} (${offsetStr})`;
+  } catch {
+    // Fallback to just the timezone name if anything goes wrong
+    return timezone.replace(/_/g, ' ');
+  }
+};
+
 export function getUserTimezone() {
     
     const userTimezone =  Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
Summary
Updates timezone dropdowns to show UTC offsets (e.g., America/New York (UTC-05:00)). Adds a guard around Firebase Analytics initialization to prevent runtime errors when offline.
Changes
Added formatTimezoneLabel() to compute and display UTC offsets for timezone names
Updated TimezonePicker and TimezoneChanger to use formatted labels
Wrapped Firebase Analytics initialization with environment checks to prevent offline errors
