### PR TITLE
[tiny fix] group calendar background on dark mode

### DIFF
--- a/src/components/selectCalendarComponents/CalBlock.tsx
+++ b/src/components/selectCalendarComponents/CalBlock.tsx
@@ -137,7 +137,7 @@ export default function CalBlock({
 
   const getDefaultColor = useCallback(() => {
     if (!draggable) {
-      return chartedUsers ? 'white' : theme === 'light' ? '#a8a8a8' : '#404040';
+      return chartedUsers ? (theme === 'light' ? 'white' : '#2d3748') : theme === 'light' ? '#a8a8a8' : '#404040';
     }
     return theme === 'light' ? 'white' : '#2d3748';
   }, [theme, calendarFramework]);


### PR DESCRIPTION
group avails background would stay white on dark mode, which sometimes looks odd if there's large time chunks where nobody can make it the event.  

<img width="982" height="717" alt="image" src="https://github.com/user-attachments/assets/91c8093e-604c-419b-b7df-5bea07ec9057" />

instead of 

<img width="982" height="717" alt="image" src="https://github.com/user-attachments/assets/8f7b9b73-d28e-414a-9e3d-463fe2df154f" />
