### PR TITLE
Connor/attach cache functions to add and delete functions.

### DIFF
--- a/src/backend/events.ts
+++ b/src/backend/events.ts
@@ -30,6 +30,10 @@ import { runTransaction } from 'firebase/firestore';
 import { doTimezoneChange } from '../components/utils/functions/timzoneConversions';
 import { getUserTimezone } from '../components/utils/functions/timzoneConversions';
 import { AccountsPageEvent } from '../components/Accounts/AccountsPage';
+import {
+  removeCachedAccountEvent,
+  upsertCachedAccountEvent,
+} from '../components/Accounts/accountEventsCache';
 // ASSUME names are unique within an event
 
 let workingEvent: Event = {
@@ -193,6 +197,11 @@ async function deleteEvent(id: EventId): Promise<void> {
   });
 
   removeEventFromUserCollection(getAccountId(), id);
+  // Keep local account events cache in sync (Accounts page).
+  const accountId = getAccountId();
+  if (accountId) {
+    removeCachedAccountEvent(accountId, id);
+  }
 }
 
 // Structure of the userEvents array in the user document
@@ -371,6 +380,18 @@ async function createEvent(eventDetails: EventDetails): Promise<Event | null> {
           userEvents: arrayUnion(eventDetailsForUser),
         })
           .then(() => {
+            const row: AccountsPageEvent = {
+              name: eventDetails.name,
+              id,
+              dates: 'TBD',
+              startTime: 'TBD',
+              endTime: 'TBD',
+              location: 'TBD',
+              iAmCreator: true,
+              dateCreated: new Date(),
+              lastModified: new Date(),
+            };
+            upsertCachedAccountEvent(eventDetails.adminAccountId, row);
             resolve(newEvent);
           })
           .catch((err) => {

--- a/src/components/Accounts/AccountsPage.tsx
+++ b/src/components/Accounts/AccountsPage.tsx
@@ -118,8 +118,6 @@ export default function AccountsPage() {
                 const next =
                   events?.filter((e) => e.id !== selectedEventToDelete.id) ?? [];
                 setEvents(next);
-                const accountID = getAccountId();
-                if (accountID) setCachedAccountEvents(accountID, next);
               })
               .catch((err) => {});
             setSelectedEventToDelete(null);
@@ -242,9 +240,6 @@ export default function AccountsPage() {
                                       events?.filter((e) => e.id !== event.id) ??
                                       [];
                                     setEvents(next);
-                                    const accountID = getAccountId();
-                                    if (accountID)
-                                      setCachedAccountEvents(accountID, next);
                                   })
                                   .catch((err) => {});
                               } else {

--- a/src/components/Accounts/accountEventsCache.ts
+++ b/src/components/Accounts/accountEventsCache.ts
@@ -55,3 +55,28 @@ export function setCachedAccountEvents(
     // Ignore quota / private mode errors
   }
 }
+
+// Removes a single event from the cached account events list (if present).
+export function removeCachedAccountEvent(accountID: string, eventId: string): void {
+  const cached = getCachedAccountEvents(accountID);
+  if (cached == null) return;
+  const target = eventId.toUpperCase();
+  const next = cached.filter((e) => (e.id || '').toUpperCase() !== target);
+  setCachedAccountEvents(accountID, next);
+}
+
+// Adds or updates a single event row in the cached account events list.
+// If there is no existing cache, this will create it.
+export function upsertCachedAccountEvent(
+  accountID: string,
+  event: AccountsPageEvent
+): void {
+  const cached = getCachedAccountEvents(accountID) ?? [];
+  const target = (event.id || '').toUpperCase();
+  const existingIdx = cached.findIndex((e) => (e.id || '').toUpperCase() === target);
+  const next =
+    existingIdx === -1
+      ? [event, ...cached]
+      : cached.map((e) => ((e.id || '').toUpperCase() === target ? event : e));
+  setCachedAccountEvents(accountID, next);
+}


### PR DESCRIPTION
There was a known issue with cache deletion being delayed on the dashboard page when you delete an event from there. This was a result of the addToCache and deleteFromCache functions being attached to individual onClick functions for buttons instead of the add and remove events from the DB functions. There was also an issue with the caching due to the uppercase and lowercase ID comparison.